### PR TITLE
Transform menu to navbar on game start, add score and controls

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5,11 +5,10 @@
 
 }
 
-#menu{
+.menu{
     background-image: url(../img/whack-a-mole-Photoroom.png);
     background-repeat: no-repeat ;
     background-size:cover;
-    /* background-position-y: -100px; */
     height: 100vh;
     display: flex;
     flex-direction: column;
@@ -44,23 +43,43 @@ h3{
     align-items: flex-end;
 
 }
-
-.level{
+.level {
     display: flex;
     justify-content: center;
     margin-top: 20px;
+    align-items: center;
+}
 
-}
-#level{
-    border-radius: 10px;
-    height: 4rem;
-    width: 14rem;
-    background-color: #fff;
-    display: flex;
+#level {
+    border-radius: 12px;
+    height: 2.5rem;
+    width: 10rem;
+    background-color: #f9f9f9;
+    color: #333;
     text-align: center;
-    font-size: 20px;
-    border: none;
+    font-size: 18px;
+    padding: 0 1rem;
+    border: 2px solid #ddd;
+    box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1);
+    transition: all 0.3s ease;
+    appearance: none; /* Hides the default arrow */
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="%23333"><path d="M7 10l5 5 5-5H7z"/></svg>'); /* Custom arrow icon */
+    background-repeat: no-repeat;
+    background-position: right 1rem center;
+    background-size: 1.5rem;
 }
+
+#level:hover {
+    border-color: #a5a5a5;
+    box-shadow: 0px 6px 12px rgba(0, 0, 0, 0.15);
+}
+
+#level:focus {
+    outline: none;
+    border-color: #333;
+    box-shadow: 0px 0px 8px rgba(51, 51, 51, 0.3);
+}
+
 
 main {
     display: flex;
@@ -218,4 +237,50 @@ main {
 }
 .mole-head{
     top: 162px;
+}
+
+/* reda?> */
+.hidden {
+    display: none;
+}
+
+.nav-style.nav-style {
+    justify-content: space-between;
+    align-items: center;
+    height: 80px ;
+    padding: 0 20px;
+    background-color: #653113; /* Change to a desired navbar color */
+    color: white;
+    flex-direction: row;
+}
+
+.nav-style h1 {
+    font-size: 24px;
+    color: white;
+    margin: 0;
+}
+/* Score and control buttons styling */
+#score {
+    font-size: 20px;
+    font-weight: bold;
+    color: #fff;
+    margin-right: 20px;
+}
+
+button.stop,
+button.reset {
+    padding: 8px 16px;
+    margin-left: 10px;
+    border-radius: 8px;
+    background-color: #653113;
+    color: #fff;
+    border: none;
+    font-size: 16px;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+}
+
+button.stop:hover,
+button.reset:hover {
+    background-color: #3e2a18;
 }

--- a/index.html
+++ b/index.html
@@ -8,10 +8,10 @@
 </head>
 <body>
     
-<section id="menu">
+<section class="menu">
 
     <div class="btn">
-        <button class="start">START</button>
+        <button class="start" onclick="startGame()">START</button>
     </div>
     
     <div class="level">
@@ -21,10 +21,14 @@
             <option value="Hard">Hard</option>
         </select>
     </div>
+    <!-- New elements for score and controls -->
+    <div id="score" class="hidden">Score: 0</div>
+    <button class="stop hidden" onclick="stopGame()">Stop</button>
+    <button class="reset hidden" onclick="resetGame()">Reset</button>  
     
 </section>
 
-    <main>
+    <main class="hidden">
     
         <div class="mole-container">
             <!-- Mole 1 -->
@@ -79,6 +83,6 @@
             
         </div>
     </main>
-   
+   <script src="js/main.js"></script>
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,27 @@
+function startGame() {
+    const menu = document.querySelector(".menu"); // Updated to match your menu ID
+    const startBtn = document.querySelector(".btn");
+    const level = document.querySelector(".level");
+    const main = document.querySelector("main");
+
+    // Add navigation styling to the menu
+    menu.classList.add("nav-style");
+
+    // Hide the start button 
+    startBtn.style.display = "none";
+    document.querySelector(".level").style.marginTop = "0";
+
+
+    // Show the main game area
+    main.classList.remove("hidden");
+
+    // Show score, stop, and reset controls
+    const score = document.getElementById("score");
+    const stopBtn = document.querySelector(".stop");
+    const resetBtn = document.querySelector(".reset");
+
+    score.classList.remove("hidden");
+    stopBtn.classList.remove("hidden");
+    resetBtn.classList.remove("hidden");
+
+}


### PR DESCRIPTION
- Implemented JavaScript function to hide start button and level selector on game start
- Transformed #menu into a fixed navbar displaying score, stop, and reset controls
- Styled level selector dropdown for improved visual clarity
- Adjusted .level margin dynamically on game start for proper alignment
- Made main game area hidden by default and displayed upon game start